### PR TITLE
expose deltalake worker memory tuning options

### DIFF
--- a/charts/materializationengine/Chart.yaml
+++ b/charts/materializationengine/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: materializationengine
 description: A Helm chart for CAVE materialization service on Kubernetes
-version: 5.24.1
+version: 5.24.1-r1
 appVersion: "5.24.1"

--- a/charts/materializationengine/templates/celery_deltalake.yaml
+++ b/charts/materializationengine/templates/celery_deltalake.yaml
@@ -105,10 +105,10 @@ spec:
             requests:
               cpu: {{ .Values.materialize.celeryDeltalakeCpu }}
               memory: {{ .Values.materialize.celeryDeltalakeMemory }}
-            {{- if .Values.materialize.celeryDeltalakeMemoryLimit }}
+{{ if .Values.materialize.celeryDeltalakeMemoryLimit }}
             limits:
               memory: {{ .Values.materialize.celeryDeltalakeMemoryLimit }}
-            {{- end }}
+{{ end }}
           lifecycle:
             preStop:
               exec:

--- a/charts/materializationengine/templates/celery_deltalake.yaml
+++ b/charts/materializationengine/templates/celery_deltalake.yaml
@@ -105,6 +105,10 @@ spec:
             requests:
               cpu: {{ .Values.materialize.celeryDeltalakeCpu }}
               memory: {{ .Values.materialize.celeryDeltalakeMemory }}
+            {{- if .Values.materialize.celeryDeltalakeMemoryLimit }}
+            limits:
+              memory: {{ .Values.materialize.celeryDeltalakeMemoryLimit }}
+            {{- end }}
           lifecycle:
             preStop:
               exec:

--- a/charts/materializationengine/templates/configmap.yaml
+++ b/charts/materializationengine/templates/configmap.yaml
@@ -82,11 +82,11 @@ data:
     DELTALAKE_OUTPUT_BUCKET = "{{ .Values.materialize.dumpBucketPath }}/deltalake_exports"
     {{- end }}
     {{- if .Values.materialize.deltalakeFlushThresholdBytes }}
-    DELTALAKE_FLUSH_THRESHOLD_BYTES = {{ .Values.materialize.deltalakeFlushThresholdBytes }}
+    DELTALAKE_FLUSH_THRESHOLD_BYTES = {{ .Values.materialize.deltalakeFlushThresholdBytes | int64 }}
     {{- end }}
     {{- if .Values.materialize.deltalakeOptimizeTargetSizeBytes }}
-    DELTALAKE_OPTIMIZE_TARGET_SIZE_BYTES = {{ .Values.materialize.deltalakeOptimizeTargetSizeBytes }}
+    DELTALAKE_OPTIMIZE_TARGET_SIZE_BYTES = {{ .Values.materialize.deltalakeOptimizeTargetSizeBytes | int64 }}
     {{- end }}
     {{- if .Values.materialize.deltalakeOptimizeMaxSpillSizeBytes }}
-    DELTALAKE_OPTIMIZE_MAX_SPILL_SIZE_BYTES = {{ .Values.materialize.deltalakeOptimizeMaxSpillSizeBytes }}
+    DELTALAKE_OPTIMIZE_MAX_SPILL_SIZE_BYTES = {{ .Values.materialize.deltalakeOptimizeMaxSpillSizeBytes | int64 }}
     {{- end }}

--- a/charts/materializationengine/templates/configmap.yaml
+++ b/charts/materializationengine/templates/configmap.yaml
@@ -81,3 +81,12 @@ data:
     {{- else if .Values.materialize.dumpBucketPath }}
     DELTALAKE_OUTPUT_BUCKET = "{{ .Values.materialize.dumpBucketPath }}/deltalake_exports"
     {{- end }}
+    {{- if .Values.materialize.deltalakeFlushThresholdBytes }}
+    DELTALAKE_FLUSH_THRESHOLD_BYTES = {{ .Values.materialize.deltalakeFlushThresholdBytes }}
+    {{- end }}
+    {{- if .Values.materialize.deltalakeOptimizeTargetSizeBytes }}
+    DELTALAKE_OPTIMIZE_TARGET_SIZE_BYTES = {{ .Values.materialize.deltalakeOptimizeTargetSizeBytes }}
+    {{- end }}
+    {{- if .Values.materialize.deltalakeOptimizeMaxSpillSizeBytes }}
+    DELTALAKE_OPTIMIZE_MAX_SPILL_SIZE_BYTES = {{ .Values.materialize.deltalakeOptimizeMaxSpillSizeBytes }}
+    {{- end }}

--- a/charts/materializationengine/templates/orchestration_configmap.yaml
+++ b/charts/materializationengine/templates/orchestration_configmap.yaml
@@ -80,6 +80,15 @@ data:
     {{- else if .Values.materialize.dumpBucketPath }}
     DELTALAKE_OUTPUT_BUCKET = "{{ .Values.materialize.dumpBucketPath }}/deltalake_exports"
     {{- end }}
+    {{- if .Values.materialize.deltalakeFlushThresholdBytes }}
+    DELTALAKE_FLUSH_THRESHOLD_BYTES = {{ .Values.materialize.deltalakeFlushThresholdBytes }}
+    {{- end }}
+    {{- if .Values.materialize.deltalakeOptimizeTargetSizeBytes }}
+    DELTALAKE_OPTIMIZE_TARGET_SIZE_BYTES = {{ .Values.materialize.deltalakeOptimizeTargetSizeBytes }}
+    {{- end }}
+    {{- if .Values.materialize.deltalakeOptimizeMaxSpillSizeBytes }}
+    DELTALAKE_OPTIMIZE_MAX_SPILL_SIZE_BYTES = {{ .Values.materialize.deltalakeOptimizeMaxSpillSizeBytes }}
+    {{- end }}
     # Celery worker autoshutdown settings for orchestration pods
     CELERY_WORKER_AUTOSHUTDOWN_ENABLED = {{ if hasKey .Values.materialize "orchestrationAutoshutdownEnabled" }}{{ if .Values.materialize.orchestrationAutoshutdownEnabled }}True{{ else }}False{{ end }}{{ else }}True{{ end }}
     CELERY_WORKER_AUTOSHUTDOWN_MAX_TASKS = {{ .Values.materialize.orchestrationAutoshutdownMaxTasks | default 1 }}

--- a/charts/materializationengine/templates/orchestration_configmap.yaml
+++ b/charts/materializationengine/templates/orchestration_configmap.yaml
@@ -81,13 +81,13 @@ data:
     DELTALAKE_OUTPUT_BUCKET = "{{ .Values.materialize.dumpBucketPath }}/deltalake_exports"
     {{- end }}
     {{- if .Values.materialize.deltalakeFlushThresholdBytes }}
-    DELTALAKE_FLUSH_THRESHOLD_BYTES = {{ .Values.materialize.deltalakeFlushThresholdBytes }}
+    DELTALAKE_FLUSH_THRESHOLD_BYTES = {{ .Values.materialize.deltalakeFlushThresholdBytes | int64 }}
     {{- end }}
     {{- if .Values.materialize.deltalakeOptimizeTargetSizeBytes }}
-    DELTALAKE_OPTIMIZE_TARGET_SIZE_BYTES = {{ .Values.materialize.deltalakeOptimizeTargetSizeBytes }}
+    DELTALAKE_OPTIMIZE_TARGET_SIZE_BYTES = {{ .Values.materialize.deltalakeOptimizeTargetSizeBytes | int64 }}
     {{- end }}
     {{- if .Values.materialize.deltalakeOptimizeMaxSpillSizeBytes }}
-    DELTALAKE_OPTIMIZE_MAX_SPILL_SIZE_BYTES = {{ .Values.materialize.deltalakeOptimizeMaxSpillSizeBytes }}
+    DELTALAKE_OPTIMIZE_MAX_SPILL_SIZE_BYTES = {{ .Values.materialize.deltalakeOptimizeMaxSpillSizeBytes | int64 }}
     {{- end }}
     # Celery worker autoshutdown settings for orchestration pods
     CELERY_WORKER_AUTOSHUTDOWN_ENABLED = {{ if hasKey .Values.materialize "orchestrationAutoshutdownEnabled" }}{{ if .Values.materialize.orchestrationAutoshutdownEnabled }}True{{ else }}False{{ end }}{{ else }}True{{ end }}

--- a/charts/materializationengine/values.yaml
+++ b/charts/materializationengine/values.yaml
@@ -46,15 +46,11 @@ materialize:
   # Output bucket for deltalake exports. If empty, defaults to
   # "<dumpBucketPath>/deltalake_exports". Set to override the location.
   deltalakeOutputBucket: ""
-  # Delta Lake export memory tuning. Leave empty to keep the
-  # MaterializationEngine defaults (2 GiB flush threshold, no optimize
-  # spill limit).
-  #
+  # Delta Lake export memory tuning.
   # The export streams Postgres rows into an in-memory buffer and flushes
-  # when it reaches deltalakeFlushThresholdBytes. Peak worker memory is a
+  # when it reaches deltalakeFlushThresholdBytes. Peak worker memory may be a
   # multiple of this value, not equal to it, so lower it if the deltalake
-  # worker OOMs on large tables. 536870912 (512 MiB) is a reasonable
-  # starting point for tables in the hundreds of millions of rows.
+  # worker OOMs on large tables.
   deltalakeFlushThresholdBytes: ""
   # Bounds memory during the post-export optimize (z-order/compact) step.
   deltalakeOptimizeTargetSizeBytes: ""

--- a/charts/materializationengine/values.yaml
+++ b/charts/materializationengine/values.yaml
@@ -46,6 +46,19 @@ materialize:
   # Output bucket for deltalake exports. If empty, defaults to
   # "<dumpBucketPath>/deltalake_exports". Set to override the location.
   deltalakeOutputBucket: ""
+  # Delta Lake export memory tuning. Leave empty to keep the
+  # MaterializationEngine defaults (2 GiB flush threshold, no optimize
+  # spill limit).
+  #
+  # The export streams Postgres rows into an in-memory buffer and flushes
+  # when it reaches deltalakeFlushThresholdBytes. Peak worker memory is a
+  # multiple of this value, not equal to it, so lower it if the deltalake
+  # worker OOMs on large tables. 536870912 (512 MiB) is a reasonable
+  # starting point for tables in the hundreds of millions of rows.
+  deltalakeFlushThresholdBytes: ""
+  # Bounds memory during the post-export optimize (z-order/compact) step.
+  deltalakeOptimizeTargetSizeBytes: ""
+  deltalakeOptimizeMaxSpillSizeBytes: ""
   # KEDA scaling targets per-queue
   producerTargetQueueLength: 10
   consumerTargetQueueLength: 10
@@ -65,6 +78,11 @@ materialize:
   celeryConsumerMemory: "400Mi"
   celeryDeltalakeCpu: "950m"
   celeryDeltalakeMemory: "4000Mi"
+  # Optional memory ceiling for the deltalake worker. Empty means no limit
+  # (Burstable), so a runaway export is killed by the node OOM killer and
+  # may take neighbouring pods with it. Setting a limit turns that into a
+  # cgroup OOM attributable to this container.
+  celeryDeltalakeMemoryLimit: ""
   celeryProducerConcurrency: 2
   celeryConsumerConcurrency: 2
   celeryDeltalakeConcurrency: 2

--- a/charts/materializationengine/values.yaml
+++ b/charts/materializationengine/values.yaml
@@ -51,7 +51,7 @@ materialize:
   # when it reaches deltalakeFlushThresholdBytes. Peak worker memory may be a
   # multiple of this value, not equal to it, so lower it if the deltalake
   # worker OOMs on large tables.
-  deltalakeFlushThresholdBytes: ""
+  deltalakeFlushThresholdBytes: 2147483648
   # Bounds memory during the post-export optimize (z-order/compact) step.
   deltalakeOptimizeTargetSizeBytes: ""
   deltalakeOptimizeMaxSpillSizeBytes: ""
@@ -78,7 +78,7 @@ materialize:
   # (Burstable), so a runaway export is killed by the node OOM killer and
   # may take neighbouring pods with it. Setting a limit turns that into a
   # cgroup OOM attributable to this container.
-  celeryDeltalakeMemoryLimit: ""
+  celeryDeltalakeMemoryLimit: "8000Mi"
   celeryProducerConcurrency: 2
   celeryConsumerConcurrency: 2
   celeryDeltalakeConcurrency: 2


### PR DESCRIPTION
Delta Lake export buffers rows and flushes at `DELTALAKE_FLUSH_THRESHOLD_BYTES` (default 2 GiB). Peak memory is actually currently a multiple of that (will be addressed in a separate PR). 

This adds four optional values, all defaulting to empty so rendered output is unchanged for existing deployments:

- `deltalakeFlushThresholdBytes`
- `deltalakeOptimizeTargetSizeBytes`
- `deltalakeOptimizeMaxSpillSizeBytes`
- `celeryDeltalakeMemoryLimit`

The first three follow the `deltalakeOutputBucket` pattern and go into both `config.cfg` ConfigMaps. The last adds an optional `resources.limits.memory`; without it the worker is Burstable with no ceiling, so a runaway export is killed by the node OOM killer and can take neighbouring pods with it.

A separate MaterializationEngine PR will improve memory efficiency in the export itself